### PR TITLE
Input assignment

### DIFF
--- a/oooooo.lua
+++ b/oooooo.lua
@@ -423,6 +423,7 @@ function init_loops(j)
       softcut.loop_end(i,uC.bufferMinMax[i][2]+uP[i].loopLength)
       softcut.loop(i,1)
       softcut.rec(i,0)
+      
       softcut.fade_time(i,0.2)
       softcut.level_slew_time(i,params:get("slew rate"))
       softcut.rate_slew_time(i,params:get("slew rate"))

--- a/oooooo.lua
+++ b/oooooo.lua
@@ -401,8 +401,6 @@ function init_loops(j)
     if i<7 then
       -- update softcut
       softcut.level(i,0.5)
-      softcut.level_input_cut(1,i,1)
-      softcut.level_input_cut(2,i,1)
       softcut.pan(i,0)
       softcut.play(i,0)
       softcut.rate(i,1)
@@ -488,16 +486,31 @@ end
 -- updaters
 --
 function update_softcut_input()
+  
   if params:get("input type")==1 then
-    print("adc only")
+    print("input L only")
+    if i==7 then
+      softcut.level_input_cut(1,i,1)
+    end
     audio.level_adc_cut(1)
     audio.level_tape_cut(0)
-  elseif params:get("input type")==2 then
+  if params:get("input type")==2 then
+    print("input R only")
+    if i==7 then
+      softcut.level_input_cut(2,i,1)
+    end
+    audio.level_adc_cut(1)
+    audio.level_tape_cut(0)
+  elseif params:get("input type")==3 then
     print("tape only")
     audio.level_tape_cut(1)
     audio.level_adc_cut(0)
   else
-    print("tape+adc only")
+    print("tape+input L+R")
+    if i==7 then
+      softcut.level_input_cut(1,i,1)
+      softcut.level_input_cut(2,i,1)
+    end
     audio.level_adc_cut(1)
     audio.level_tape_cut(1)
   end

--- a/oooooo.lua
+++ b/oooooo.lua
@@ -423,7 +423,7 @@ function init_loops(j)
       softcut.loop_end(i,uC.bufferMinMax[i][2]+uP[i].loopLength)
       softcut.loop(i,1)
       softcut.rec(i,0)
-      
+
       softcut.fade_time(i,0.2)
       softcut.level_slew_time(i,params:get("slew rate"))
       softcut.rate_slew_time(i,params:get("slew rate"))

--- a/oooooo.lua
+++ b/oooooo.lua
@@ -408,7 +408,6 @@ function init_loops(j)
       softcut.loop_end(i,uC.bufferMinMax[i][2]+uP[i].loopLength)
       softcut.loop(i,1)
       softcut.rec(i,0)
-
       softcut.fade_time(i,0.2)
       softcut.level_slew_time(i,params:get("slew rate"))
       softcut.rate_slew_time(i,params:get("slew rate"))
@@ -486,7 +485,6 @@ end
 -- updaters
 --
 function update_softcut_input()
-  
   if params:get("input type")==1 then
     print("input L only")
     if i==7 then
@@ -494,7 +492,7 @@ function update_softcut_input()
     end
     audio.level_adc_cut(1)
     audio.level_tape_cut(0)
-  if params:get("input type")==2 then
+  elseif params:get("input type")==2 then
     print("input R only")
     if i==7 then
       softcut.level_input_cut(2,i,1)

--- a/oooooo.lua
+++ b/oooooo.lua
@@ -111,7 +111,7 @@ function init()
   params:set_action("rec thru loops",update_parameters)
   params:add_control("stop rec after","stop rec after",controlspec.new(1,64,"lin",1,1,"loops"))
   params:set_action("stop rec after",update_parameters)
-  params:add_option("input type","input type",{"line-in 1","line-in 2","tape","line-in (1+2)+tape"},4)
+  params:add_option("input type","input type",{"line-in L","line-in R","tape","line-in (L+R)+tape"},4)
   params:set_action("input type",function(x)
     update_softcut_input()
     update_parameters()
@@ -296,7 +296,7 @@ function init()
   p_amp_in.time=1
   p_amp_in.callback=function(val)
     for i=1,6 do
-      if uS.recording[i]==1 and params:get("input type")==(1 or 4) then
+      if uS.recording[i]==1 and (params:get("input type")==1 or params:get("input type")==4) then
         -- print("incoming signal = "..val)
         if val>params:get("rec thresh")/1000 then
           tape_rec(i)
@@ -312,7 +312,7 @@ function init()
   p_amp_in2.time=1
   p_amp_in2.callback=function(val)
     for i=1,6 do
-      if uS.recording[i]==1 and params:get("input type")==(2 or 4) then
+      if uS.recording[i]==1 and (params:get("input type")==2 or params:get("input type")==4) then
         -- print("incoming signal = "..val)
         if val>params:get("rec thresh")/1000 then
           tape_rec(i)
@@ -812,9 +812,9 @@ function tape_stop_rec(i,change_loop)
     do return end
   end
   print("tape_stop_rec "..i)
-  if uS.recording[i]==1 and params:get("input type")==(1 or 4) then
+  if uS.recording[i]==1 and (params:get("input type")==1 or params:get("input type")==4) then
     p_amp_in.time=1
-  elseif uS.recording[i]==1 and params:get("input type")==(2 or 4) then
+  elseif uS.recording[i]==1 and (params:get("input type")==2 or params:get("input type")==4) then
     p_amp_in2.time=1
   end
   still_armed=(uS.recording[i]==1)
@@ -955,9 +955,9 @@ function tape_arm_rec(i)
   uS.recording[i]=1
   uS.recordingLoopNum[i]=0
   -- monitor input
-  if uS.recording[i]==1 and not params:get("input type")==(1 or 4) then
+  if uS.recording[i]==1 and (params:get("input type")==1 or params:get("input type")==4) then
     p_amp_in.time=0.025
-  elseif uS.recording[i]==1 and params:get("input type")==(2 or 4) then
+  elseif uS.recording[i]==1 and (params:get("input type")==2 or params:get("input type")==4) then
     p_amp_in2.time=0.025
   end
 end
@@ -974,9 +974,9 @@ function tape_rec(i)
     uP[i].volUpdate=true
     uP[i].isStopped=false
   end
-  if uS.recording[i]==1 and not params:get("input type")==(1 or 4) then
+  if uS.recording[i]==1 and (params:get("input type")==1 or params:get("input type")==4) then
     p_amp_in.time=1
-  elseif uS.recording[i]==1 and params:get("input type")==(2 or 4) then
+  elseif uS.recording[i]==1 and (params:get("input type")==2 or params:get("input type")==4) then
     p_amp_in2.time=1
   end
   uS.recordingTime[i]=0

--- a/oooooo.lua
+++ b/oooooo.lua
@@ -291,9 +291,8 @@ function init()
   softcut.poll_start_phase()
 
   
-  -- call update_softcut_input to set polling input
-  p_amp_in = update_softcut_input()
-
+  -- and initiate recording on incoming audio
+  p_amp_in=poll.set("amp_in_l")
   -- set period low when primed, default 1 second
   p_amp_in.time=1
   p_amp_in.callback=function(val)
@@ -333,6 +332,8 @@ function init()
     tape_stop(1)
     tape_reset(1)
   end
+
+  update_softcut_input()
 end
 
 function init_loops(j)
@@ -485,8 +486,6 @@ end
 --
 function update_softcut_input()  
     if params:get("input type")==1 then
-      p_amp_in=poll.set("amp_in_l")
-      print("listening on input 1")
       for i=1,6 do
         print("input L only channel "..i)
         softcut.level_input_cut(1,i,1)
@@ -495,8 +494,6 @@ function update_softcut_input()
         audio.level_tape_cut(0)
       end
     elseif params:get("input type")==2 then
-      p_amp_in=poll.set("amp_in_r")
-      print("listening on input 2")
       for i=1,6 do
         print("input R only channel "..i)
         softcut.level_input_cut(1,i,0)

--- a/oooooo.lua
+++ b/oooooo.lua
@@ -297,7 +297,7 @@ function init()
   p_amp_in.callback=function(val)
     for i=1,6 do
       if uS.recording[i]==1 and params:get("input type")==(1 or 4) then
-        print("incoming signal = "..val)
+        -- print("incoming signal = "..val)
         if val>params:get("rec thresh")/1000 then
           tape_rec(i)
         end
@@ -313,7 +313,7 @@ function init()
   p_amp_in2.callback=function(val)
     for i=1,6 do
       if uS.recording[i]==1 and params:get("input type")==(2 or 4) then
-        print("incoming signal = "..val)
+        -- print("incoming signal = "..val)
         if val>params:get("rec thresh")/1000 then
           tape_rec(i)
         end


### PR DESCRIPTION
Adds the following features:
* Add recording from `line-in 1` or `line-in 2` independently as a global option alongside existing `tape` only mode and `line-in (1+2) + tape` modes
* Input monitoring now works on left, right or left + right channels depending on input mode selected
* renamed `line-in + tape` to `line-in (1+2) + tape` for added clarity
* set levels of unused inputs explicitly 