### PR TITLE
bug fix: set scales when loading saved settings

### DIFF
--- a/oooooo.lua
+++ b/oooooo.lua
@@ -1057,6 +1057,7 @@ function backup_load(savename)
     uP[i].rateUpdate=true
     uP[i].volUpdate=true
   end
+  build_ji_rates()
 end
 
 --


### PR DESCRIPTION
call to `build_ji_rates` added to function `backup_load`